### PR TITLE
Unmaximize clients before tiling

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -684,13 +684,14 @@ Window {
 
     /// keyboard navigation
     function selectClient(client){
+        client.setMaximize(false, false);
         const clientGeometry = client.frameGeometry;
         clientGeometry.x = mainWindow.x - (assistPadding / 2);
         clientGeometry.y = mainWindow.y - (assistPadding / 2);
         clientGeometry.width = mainWindow.width + assistPadding;
         clientGeometry.height = mainWindow.height + assistPadding;
         workspace.activeClient = client;
-        checkToShowNextQuaterAssist(client)
+        checkToShowNextQuaterAssist(client);
     }
 
     function moveFocusLeft() {


### PR DESCRIPTION
Applies the `setMaximize(false, false)` function to clients to support setups that use the `BorderlessMaximizedWindows` in kwin. 